### PR TITLE
Fix tiny typing bug with Component.Auto

### DIFF
--- a/Knit/Util/Component.d.ts
+++ b/Knit/Util/Component.d.ts
@@ -33,7 +33,7 @@ interface Component<T extends Component.ComponentClass> {
 
 interface ComponentConstructor {
 	readonly FromTag: (tag: string) => Component<Component.ComponentClass>;
-	readonly Auto: (folder: Folder) => void;
+	readonly Auto: (folder: Instance) => void;
 	new <T extends Component.ComponentClass>(
 		tag: string,
 		classConstructor: Component.ComponentClassConstructor<T>,


### PR DESCRIPTION
Instead of having the input be Instance (as it is on the Knit docs) the type takes in a Folder. This is slightly annoying as loading components requires a cast when using WaitForChild.

https://github.com/osyrisrblx/rbxts-knit/blob/0d9364b136e8a3f56d6c2479516218c3cb1db105/Knit/Util/Component.d.ts#L36